### PR TITLE
Cleanup .NET recipe.

### DIFF
--- a/attributes/dotnet_agent.rb
+++ b/attributes/dotnet_agent.rb
@@ -1,5 +1,5 @@
 default['appdynamics']['dotnet_agent']['version'] = 'latest'
-default['appdynamics']['dotnet_agent']['source'] = "http://localhost/AppdynamicsInstallers/" #'https://packages.appdynamics.com/machine/%{version}/JavaAppAgent.zip'
+default['appdynamics']['dotnet_agent']['source'] = 'http://localhost/AppdynamicsInstallers/' #'https://packages.appdynamics.com/machine/%{version}/JavaAppAgent.zip'
 default['appdynamics']['dotnet_agent']['checksum'] = '7acb3756147a1d5a13c49b107a890ea56a8eb4099fd793e498e34b6f0b5962dc' #nil
 default['appdynamics']['dotnet_agent']['install_dir'] = 'C:\Program Files\Appdynamics'
 default['appdynamics']['dotnet_agent']['logfiles_dir'] = 'C:\DotNetAgent\Logs'

--- a/recipes/dotnet_agent.rb
+++ b/recipes/dotnet_agent.rb
@@ -1,24 +1,15 @@
 agent = node['appdynamics']['dotnet_agent']
 controller = node['appdynamics']['controller']
-proxy = node['appdynamics']['http_proxy'] 
-bitness = node['kernel']['os_info']['os_architecture']
+proxy = node['appdynamics']['http_proxy']
 install_directory = agent['install_dir']
 system_directory = node['kernel']['os_info']['windows_directory']
 
-agent_msi = ""
-##################################################################################################################################
-# The below paths can also be used instead of temp direcotry. But there will be msiexec exceptions if there is space in the path #
-# agent_msi_path = "#{Chef::Config[:file_cache_path]"																			 #
-# setup_config = "#{Chef::Config[:file_cache_path]}\\setup.xml"																	 #
-# install_log_file = "#{Chef::Config[:file_cache_path]}\\DotnetAgentInstall.log"												 #
-##################################################################################################################################
 agent_msi_path = "#{system_directory}\\Temp"
 setup_config = "#{agent_msi_path}\\setup.xml"
 install_log_file = "#{agent_msi_path}\\DotnetAgentInstall.log"
 
-
 # Check the bitness of the OS to determine the installer to download and run
-case bitness
+case node['kernel']['os_info']['os_architecture']
 when /64/
   agent_msi = "#{agent_msi_path}\\dotNetAgentSetup64.msi"
   source_path = "#{agent['source']}/dotNetAgentSetup64.msi"
@@ -26,7 +17,7 @@ when /32/
   agent_msi = "#{agent_msi_path}\\dotNetAgentSetup.msi"
   source_path = "#{agent['source']}/dotNetAgentSetup.msi"
 else
-  agent_msi = "Unsupported OS bitness"
+  raise "Unsupported OS architecture"
 end
 
 # Download the msi file from source
@@ -35,56 +26,24 @@ remote_file "#{agent_msi}" do
   checksum agent['checksum']
 end
 
-#Environment Validation
-#####################################################################################################
-# Environment Validation using Powershell                                                           #
-#####################################################################################################
-# # Comment if you're installing 4.1
-# #Check whether the MSDTC service is up and running 
-# #if it is not running, start the service
-# powershell_script 'check_MSDTC' do
-    # code 'Start-Service MSDTC'
-	# only_if {'(Get-Service MSDTC).status' != "Running" }
-# end
+# Environment Validation
 
-# # Comment if you're installing 4.1 -- Matt Jensen to confirm with Sanjay
-# #Check whether the WMI service is up and running 
-# #if it is not running, start the service
-# powershell_script 'check_WMI' do
-    # code 'Start-Service Winmgmt'
-	# only_if {'(Get-Service Winmgmt).status' != "Running" }
-# end
-
-# # Comment if you're installing 4.1
-# # Check whether the COM+ service is up and running
-# # if it is not running, start the service
-# powershell_script 'check_complus' do
-	# code 'Start-Service COMSysApp'
-	# only_if {'(Get-Service COMSysApp).status' != "Running" }
-# end
-#####################################################################################################
-
-# Comment if you're installing 4.1
-# Check whether the MSDTC service is up and running 
-# if it is not running, start the service
+# MSDTC Service
 service "MSDTC" do
   action [ :enable, :start ]
 end
 
-# Comment if you're installing 4.1 -- Matt Jensen to confirm with Sanjay
-# Check whether the WMI service is up and running 
-# if it is not running, start the service
+# WMI Service
 service "Winmgmt" do
   action [ :enable, :start ]
 end
 
-# Comment if you're installing 4.1
-# Check whether the COM+ service is up and running
-# if it is not running, start the service
-service "COMSysApp" do
-  action [ :enable, :start ]
+if agent['version'] < '4.1'
+  # COM+ Service is not required in 4.1+
+  service "COMSysApp" do
+    action [ :enable, :start ]
+  end
 end
-
 
 # Check whether IIS 7.0+ is installed
 # Enable IIS Health Monitoring for the Machine snapshots to return IIS App Pool data
@@ -98,32 +57,24 @@ end
 template "#{setup_config}" do
   cookbook agent['template']['cookbook']
   source agent['template']['source']
-    
+
   variables(
-  :app_name => node['appdynamics']['app_name'],
-  :log_file_directory => agent['logfiles_dir'],
-  :controller_host => controller['host'],
-  :controller_port => controller['port'],
-  :controller_ssl => controller['ssl'],
-  :controller_user => controller['user'],
-  :controller_accesskey => controller['accesskey'],
-  :proxy_host => proxy['host'],
-  :proxy_port => proxy['port'],
+    :app_name => node['appdynamics']['app_name'],
+    :log_file_directory => agent['logfiles_dir'],
+    :controller_host => controller['host'],
+    :controller_port => controller['port'],
+    :controller_ssl => controller['ssl'],
+    :controller_user => controller['user'],
+    :controller_accesskey => controller['accesskey'],
+    :proxy_host => proxy['host'],
+    :proxy_port => proxy['port'],
   )
 end
 
-# Installing the agent 
+# Installing the agent
 windows_package 'Install AppD .NET Agent' do
   source agent_msi
   options "/lv #{install_log_file} AD_SetupFile=#{setup_config} INSTALLDIR=\"#{install_directory}\""
   installer_type :msi
- only_if { File.exists?(agent_msi) }  
+  only_if { File.exists?(agent_msi) }
 end
-
-
-## Installing the agent -- No Dependency on windows cookbook
-## The below code block can also be used for installing the agent
-# execute "install #{agent_msi}" do
-#   command "msiexec /i #{agent_msi} /q /norestart /lv #{install_log_file} AD_SetupFile=#{setup_config} INSTALLDIR=\"#{install_directory}\""
-#  only_if { File.exists?(agent_msi) }
-# end


### PR DESCRIPTION
This is mostly minor style fixes. The one substantive change is
that we selectively enable the required services based on the
version set in node['appdynamics']['dotnet_agent']['version'].

For all versions, we enable MSDTC and WMI. For versions before
4.1, we also enable COM+. Required services were pulled from the
documentation here:

https://docs.appdynamics.com/display/PRO40/Install+the+.NET+Agent
https://docs.appdynamics.com/display/PRO41/Install+the+.NET+Agent