### PR TITLE
Dotnet add standalone instrumentation

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -141,6 +141,7 @@ suites:
           accesskey: controller-accesskey
         dotnet_agent:
           instrument_iis: true
+          standalone_apps: [{name: W3SVC, executable: svchost.exe, tier: w3svc, commandline: -k iissvcs, restart: false },{name: MSDTC, executable: msdtc.exe, tier: msdtc, commandline: , restart: true}]
     chef_client:
       config:
         log_level: :debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ appdynamics CHANGELOG
 
 This file is used to list changes made in each version of the appdynamics cookbook.
 
+0.1.1
+-----
+- [Al Kemner] - dotnet_agent - add standalone/windows service instrumentation support, includes chefspec and serverspec test for the changes. 
+
 0.1.0
 -----
 - [Al Kemner] - bump metadata version, add changelog.md, resolve FoodCritic/Rubocop failures for all files, add unit(chefspec) & integration(serverspec) testing for dotnet_agent.rb. remove checksum, notify to template resource so AppDynamics Agent Coordinator restart if template gets changed, subscribe IIS Restart script to AppDynamics Agent Coordinator. 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ The `dotnet_agent` recipe has some additional attributes you may set:
 * `node['appdynamics']['dotnet_agent']['version']` - The version of the .net agent you wish to use. defaults to `latest`
 * `node['appdynamics']['dotnet_agent']['install_dir']` - Set to the path you want the agent to be installed at, it defaults to `C:\Program Files\Appdynamics`.
 * `node['appdynamics']['dotnet_agent']['source']` - base url for downloading the agent from.
-* `node['appdynamics']['dotnet_agent']['logfiles_dir']` - Set the logfile directory. defaults to `C:\DotNetAgent\Logs`. 
+* `node['appdynamics']['dotnet_agent']['logfiles_dir']` - Set the logfile directory. defaults to `C:\DotNetAgent\Logs`.
+* `node['appdynamics']['dotnet_agent']['instrument_iis']` - defaults to false. override to `true` if iis instrumentation is needed.
+* `node['appdynamics']['dotnet_agent']['standalone_apps']` - defaults to nil. use this to instrument windows services and/or standalone apps. make sure restart = false for apps that are not windows services, because the service resource will fail trying to restart a non-windows service.
 
 ## Usage
 
@@ -123,6 +125,8 @@ The `dotnet_agent` recipe has some additional attributes you may set:
 * `node['appdynamics']['controller']['port']`
 * `node['appdynamics']['controller']['user']`
 * `node['appdynamics']['controller']['accesskey']`
+* `node['appdynamics']['dotnet_agent']['instrument_iis']`
+* `node['appdynamics']['dotnet_agent']['standalone_apps']`
 
 For example, you might set these in a Chef role file:
 
@@ -135,7 +139,18 @@ default_attributes (
       'port' => '8181',
       'ssl' => true,
       'user' => 'someuser',
-      'accesskey' => 'supersecret',
+      'accesskey' => 'supersecret'
+    }
+    'dotnet_agent' => {
+      'instrument_iis' => true,
+      'standalone_apps' => [
+        {
+          'name' => 'WindowsServiceNameA', 'executable' => 'a.exe', 'tier' => 'TierA', 'commandline' => 'nil', 'restart' => true
+        },
+        {
+          'name' => 'ExecutableNameB', 'executable' => 'b.exe', 'tier' => 'TierB', 'commandline' => '-a -b', 'restart' => false
+        }
+      ]
     }
   }
 )

--- a/attributes/dotnet_agent.rb
+++ b/attributes/dotnet_agent.rb
@@ -13,3 +13,16 @@ if node['kernel']['machine'] != 'x86_64'
 else
   default['appdynamics']['dotnet_agent']['package_file'] = 'dotNetAgentSetup64.msi'
 end
+
+# instrumenting windows services and/or standalone apps
+# standalone apps must have restart = false because the service resource will fail trying to restart a non-windows service
+default['appdynamics']['dotnet_agent']['standalone_apps'] = nil
+# example useage
+# default['appdynamics']['dotnet_agent']['standalone_apps'] = [
+#   {
+#     'name' => 'WindowsServiceNameA', 'executable' => 'a.exe', 'tier' => 'TierA', 'commandline' => 'nil', 'restart' => true
+#   },
+#   {
+#     'name' => 'ExecutableNameB', 'executable' => 'b.exe', 'tier' => 'TierB', 'commandline' => '-a -b', 'restart' => false
+#   }
+# ]

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name 'appdynamics'
 maintainer 'Appdynamics'
 description 'Installs/Configures appdynamic agents'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version '0.1.1'
 
 depends 'windows'
 depends 'python'

--- a/spec/unit/dotnet_agent_spec.rb
+++ b/spec/unit/dotnet_agent_spec.rb
@@ -7,6 +7,14 @@ describe 'appdynamics::dotnet_agent' do
         node.automatic['kernel']['machine'] = 'x86_64'
         node.set['appdynamics']['dotnet_agent']['template']['cookbook'] = 'appdynamics'
         node.set['appdynamics']['dotnet_agent']['template']['source'] = 'dotnet/setup.config.erb'
+        node.set['appdynamics']['dotnet_agent']['standalone_apps'] = [
+          {
+            'name' => 'WindowsServiceNameA', 'executable' => 'a.exe', 'tier' => 'TierA', 'commandline' => 'nil', 'restart' => true
+          },
+          {
+            'name' => 'ExecutableNameB', 'executable' => 'b.exe', 'tier' => 'TierB', 'commandline' => '-a -b', 'restart' => false
+          }
+        ]
         node.set['appdynamics']['app_name'] = 'myapp'
         node.set['appdynamics']['controller']['host'] = 'appdynamics-controller.domain.com'
         node.set['appdynamics']['controller']['port'] = '443'
@@ -20,19 +28,19 @@ describe 'appdynamics::dotnet_agent' do
     it 'creates a temp directory' do
       expect(chef_run).to create_directory('temp')
     end
-    it 'enables MSDTC service' do
+    it 'enables & starts MSDTC service' do
       expect(chef_run).to enable_service('MSDTC')
       expect(chef_run).to start_service('MSDTC')
     end
-    it 'enables Winmgmt service' do
+    it 'enables & starts Winmgmt service' do
       expect(chef_run).to enable_service('Winmgmt')
       expect(chef_run).to start_service('Winmgmt')
     end
-    it 'does not enable COMSysApp service' do
+    it 'does not enable or start COMSysApp service' do
       expect(chef_run).to_not enable_service('COMSysApp')
       expect(chef_run).to_not start_service('COMSysApp')
     end
-    it 'enables COMSysApp service' do
+    it 'enables & starts COMSysApp service' do
       chef_run.node.set['appdynamics']['dotnet_agent']['version'] = '4.0.8.0'
       chef_run.converge(described_recipe)
       expect(chef_run).to enable_service('COMSysApp')
@@ -47,7 +55,7 @@ describe 'appdynamics::dotnet_agent' do
     it 'installs package AppDynamics .NET Agent' do
       expect(chef_run).to install_package('AppDynamics .NET Agent')
     end
-    it 'enables AppDynamics.Agent.Coordinator_service' do
+    it 'enables & starts AppDynamics.Agent.Coordinator_service' do
       expect(chef_run).to enable_service('AppDynamics.Agent.Coordinator_service')
       expect(chef_run).to start_service('AppDynamics.Agent.Coordinator_service')
     end
@@ -72,6 +80,18 @@ describe 'appdynamics::dotnet_agent' do
       chef_run.converge(described_recipe)
       expect(chef_run).to_not run_powershell_script('Restart IIS')
     end
+    it 'service WindowsServiceNameA subscribes to service AppDynamics.Agent.Coordinator_service' do
+      expect(chef_run.service('WindowsServiceNameA')).to subscribe_to('service[AppDynamics.Agent.Coordinator_service]').delayed
+    end
+    it 'service WindowsServiceNameA subscribes to package AppDynamics .NET Agent' do
+      expect(chef_run.service('WindowsServiceNameA')).to subscribe_to('package[AppDynamics .NET Agent]').delayed
+    end
+    it 'service WindowsServiceNameA to do nothing' do
+      expect(chef_run.service('WindowsServiceNameA')).to do_nothing
+    end
+    it 'service ExecutableNameB to do nothing' do
+      expect(chef_run.service('ExecutableNameB')).to do_nothing
+    end
   end
   context 'win2012r2' do
     let(:chef_run) do
@@ -79,6 +99,14 @@ describe 'appdynamics::dotnet_agent' do
         node.automatic['kernel']['machine'] = 'x86_64'
         node.set['appdynamics']['dotnet_agent']['template']['cookbook'] = 'appdynamics'
         node.set['appdynamics']['dotnet_agent']['template']['source'] = 'dotnet/setup.config.erb'
+        node.set['appdynamics']['dotnet_agent']['standalone_apps'] = [
+          {
+            'name' => 'WindowsServiceNameA', 'executable' => 'a.exe', 'tier' => 'TierA', 'commandline' => 'nil', 'restart' => true
+          },
+          {
+            'name' => 'ExecutableNameB', 'executable' => 'b.exe', 'tier' => 'TierB', 'commandline' => '-a -b', 'restart' => false
+          }
+        ]
         node.set['appdynamics']['app_name'] = 'myapp'
         node.set['appdynamics']['controller']['host'] = 'appdynamics-controller.domain.com'
         node.set['appdynamics']['controller']['port'] = '443'
@@ -92,19 +120,19 @@ describe 'appdynamics::dotnet_agent' do
     it 'creates a temp directory' do
       expect(chef_run).to create_directory('temp')
     end
-    it 'enables MSDTC service' do
+    it 'enables & starts MSDTC service' do
       expect(chef_run).to enable_service('MSDTC')
       expect(chef_run).to start_service('MSDTC')
     end
-    it 'enables Winmgmt service' do
+    it 'enables & starts Winmgmt service' do
       expect(chef_run).to enable_service('Winmgmt')
       expect(chef_run).to start_service('Winmgmt')
     end
-    it 'does not enable COMSysApp service' do
+    it 'does not enable or start COMSysApp service' do
       expect(chef_run).to_not enable_service('COMSysApp')
       expect(chef_run).to_not start_service('COMSysApp')
     end
-    it 'enables COMSysApp service' do
+    it 'enables & starts COMSysApp service' do
       chef_run.node.set['appdynamics']['dotnet_agent']['version'] = '4.0.8.0'
       chef_run.converge(described_recipe)
       expect(chef_run).to enable_service('COMSysApp')
@@ -119,7 +147,7 @@ describe 'appdynamics::dotnet_agent' do
     it 'installs package AppDynamics .NET Agent' do
       expect(chef_run).to install_package('AppDynamics .NET Agent')
     end
-    it 'enables AppDynamics.Agent.Coordinator_service' do
+    it 'enables & starts AppDynamics.Agent.Coordinator_service' do
       expect(chef_run).to enable_service('AppDynamics.Agent.Coordinator_service')
       expect(chef_run).to start_service('AppDynamics.Agent.Coordinator_service')
     end
@@ -138,6 +166,18 @@ describe 'appdynamics::dotnet_agent' do
       chef_run.node.set['appdynamics']['dotnet_agent']['instrument_iis'] = true
       chef_run.converge(described_recipe)
       expect(chef_run).to_not run_powershell_script('Restart IIS')
+    end
+    it 'service WindowsServiceNameA subscribes to service AppDynamics.Agent.Coordinator_service' do
+      expect(chef_run.service('WindowsServiceNameA')).to subscribe_to('service[AppDynamics.Agent.Coordinator_service]').delayed
+    end
+    it 'service WindowsServiceNameA subscribes to package AppDynamics .NET Agent' do
+      expect(chef_run.service('WindowsServiceNameA')).to subscribe_to('package[AppDynamics .NET Agent]').delayed
+    end
+    it 'service WindowsServiceNameA to do nothing' do
+      expect(chef_run.service('WindowsServiceNameA')).to do_nothing
+    end
+    it 'service ExecutableNameB to do nothing' do
+      expect(chef_run.service('ExecutableNameB')).to do_nothing
     end
   end
 end

--- a/templates/default/dotnet/setup.config.erb
+++ b/templates/default/dotnet/setup.config.erb
@@ -17,6 +17,15 @@
       <IIS>
         <automatic enabled="<%= @instrument_iis%>" />
       </IIS>
+      <% unless @standalone_apps.nil? %> 
+      <standalone-applications> 
+      <% @standalone_apps.each do |app| %>
+        <standalone-application executable="<%= app[:executable]%>" <% unless app[:commandline].nil? %> command-line="<%= app[:commandline]%>" <% end %>>
+          <tier name="<%= app[:tier]%>" />
+        </standalone-application>
+      <% end %>
+      </standalone-applications>
+      <% end %>
     </app-agents>
   </appdynamics-agent>
 </winston>

--- a/test/integration/dotnet_agent/serverspec/dotnet_agent_spec.rb
+++ b/test/integration/dotnet_agent/serverspec/dotnet_agent_spec.rb
@@ -30,6 +30,12 @@ describe file('c:\\windows\\Temp\\setup.xml') do
   it 'is a file' do
     expect(subject).to be_file
   end
+  it { should contain 'automatic enabled="true"' }
+  it { should contain 'svchost.exe' }
+  it { should contain 'msdtc.exe' }
+  it { should contain 'command-line="-k iissvcs"' }
+  it { should contain 'name="msdtc"' }
+  it { should contain 'name="w3svc"' }
 end
 describe package('AppDynamics .NET Agent') do
   it 'is installed' do


### PR DESCRIPTION
This PR adds standalone/windows service instrumentation for the dotnet_agent. includes updated chefspec and serverspec tests. 

@thiru-chidambaram @dkoepke 