### PR TITLE
Add support for packages.appdynamics.com, remove "latest" version concept.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,23 @@ driver:
 
 provisioner:
   name: chef_zero
+  attributes:
+    appdynamics:
+      version: '4.1.2.0'
+      app_name: test-app
+      tier_name: test-tier
+      node_name: test-node
+      controller:
+        host: controller-host
+        port: 1234
+        ssl: true
+        user: controller-user
+        accesskey: controller-accesskey
+        http_proxy:
+          host: http-proxy-host
+          port: 2345
+          user: http-proxy-user
+          password_file: /tmp/foo/bar
 
 platforms:
   - name: ubuntu-12.04
@@ -31,20 +48,6 @@ suites:
       nodejs:
         install_method: source
       appdynamics:
-        app_name: test-app
-        tier_name: test-tier
-        node_name: test-node
-        controller:
-          host: controller-host
-          port: 1234
-          ssl: true
-          user: controller-user
-          accesskey: controller-accesskey
-          http_proxy:
-            host: http-proxy-host
-            port: 2345
-            user: http-proxy-user
-            password_file: /tmp/foo/bar
         nodejs_agent:
           path: /home/vagrant
     excludes:
@@ -57,23 +60,9 @@ suites:
       - recipe[appdynamics::python_agent]
     attributes:
       appdynamics:
-        app_name: test-app
-        tier_name: test-tier
-        node_name: test-node
-        controller:
-          host: controller-host
-          port: 1234
-          ssl: true
-          user: controller-user
-          accesskey: controller-accesskey
-          http_proxy:
-            host: http-proxy-host
-            port: 2345
-            user: http-proxy-user
-            password_file: /tmp/foo/bar
-          python_agent:
-            debug: true
-            dir: '/opt/pyagent'
+        python_agent:
+          debug: true
+          dir: '/opt/pyagent'
     excludes:
     - windows2012
     - windows2008r2
@@ -83,24 +72,6 @@ suites:
       - recipe[apt::default]
       - recipe[java::default]
       - recipe[appdynamics::machine_agent]
-    attributes:
-      appdynamics:
-        app_name: test-app
-        tier_name: test-tier
-        node_name: test-node
-        controller:
-          host: controller-host
-          port: 1234
-          ssl: true
-          user: controller-user
-          accesskey: controller-accesskey
-          http_proxy:
-            host: http-proxy-host
-            port: 2345
-            user: http-proxy-user
-            password_file: /tmp/foo/bar
-        machine_agent:
-          source: http://10.0.72.177:10000/MachineAgent.zip
     excludes:
     - windows2012
     - windows2008r2
@@ -109,19 +80,6 @@ suites:
     run_list:
       - recipe[apt::default]
       - recipe[appdynamics::java_agent]
-    attributes:
-      appdynamics:
-        app_name: test-app
-        tier_name: test-tier
-        node_name: test-node
-        controller:
-          host: controller-host
-          port: 1234
-          ssl: true
-          user: controller-user
-          accesskey: controller-accesskey
-        java_agent:
-          source: http://10.0.72.177:10000/JavaAppAgent.zip
     excludes:
     - windows2012
     - windows2008r2
@@ -132,13 +90,6 @@ suites:
       - recipe[appdynamics::dotnet_agent]
     attributes:
       appdynamics:
-        app_name: test-app
-        controller:
-          host: controller-host
-          port: 443
-          ssl: true
-          user: controller-user
-          accesskey: controller-accesskey
         dotnet_agent:
           instrument_iis: true
           standalone_apps: [{name: W3SVC, executable: svchost.exe, tier: w3svc, commandline: -k iissvcs, restart: false },{name: MSDTC, executable: msdtc.exe, tier: msdtc, commandline: , restart: true}]

--- a/README.md
+++ b/README.md
@@ -34,16 +34,21 @@ For more information about these settings, please refer to the AppDynamics docum
 
 ### Default Attributes
 
-These attributes are used with the `_agent` recipes:
+These node attributes must be set to use the `_agent` recipes:
 
 * `node['appdynamics']['app_name']` - The name to register your application under with the AppDynamics controller.
 * `node['appdynamics']['tier_name']` - The name to register this tier of your application under with the AppDynamics controller.
 * `node['appdynamics']['node_name']` - The name to register this node of your application under with the AppDynamics controller.
+* `node['appdynamics']['version']` - The version of AppDynamics to use.
 * `node['appdynamics']['controller']['host']` - The host your AppDynamics controller is running on (a domain name or IP address). **Required**
 * `node['appdynamics']['controller']['port']` - The port your AppDynamics controller is running on.
+* `node['appdynamics']['controller']['user']` - The account name to use with your AppDynamics controller.
+* `node['appdynamics']['controller']['accesskey']` - The access key for your account for accessing your AppDynamics controller.
+
+Optional attributes:
+
+* `node['appdynamics']['packages_site']` - The base URL of the AppDynamics packages site (defaults to `https://packages.appdynamics.com`).
 * `node['appdynamics']['controller']['ssl']` - Flag indicating if SSL should be used to speak to the controller (`true`) or not (`false`). Defaults to `true`. SaaS controllers do not support the value `false` for this flag.
-* `node['appdynamics']['controller']['user']` - If you need to authenticate with your controller, the account name.
-* `node['appdynamics']['controller']['accesskey']` - If you need to authenticate with your controller, the accesskey for accessing your AppDynamics controller.
 
 ### HTTP Proxy Attributes
 
@@ -59,9 +64,10 @@ If your agents must use an HTTP proxy to communicate with the controller, set th
 The `python_agent` recipe has some additional attributes you may set:
 
 * `node['appdynamics']['python_agent']['virtualenv']` - The path to the Python virtualenv to install the Python agent into.
-* `node['appdynamics']['python_agent']['version']` - The version of the Python agent you wish to use. If not set, `latest`.
+* `node['appdynamics']['python_agent']['version']` - The version of the Python agent you wish to use. If set, overrides the version set in `node['appdynamics']['version']`.
 * `node['appdynamics']['python_agent']['debug']` - If set to `true`, the Python agent will start in debug mode.
 * `node['appdynamics']['python_agent']['dir']` - Set to the path you want the agent to use for storing its runtime data. It defaults to `/tmp/appd`.
+* `node['appdynamics']['python_agent']['source']` - Specify a full URL here if you wish to download the Python agent from another location than the default packages site.
 
 ## Usage
 
@@ -69,6 +75,7 @@ The `python_agent` recipe has some additional attributes you may set:
 
 **Step 1.** Set the following node attributes (documented above):
 
+* `node['appdynamics']['version']` *OR* `node['appdynamics']['python_agent']['version']`
 * `node['appdynamics']['app_name']`
 * `node['appdynamics']['tier_name']`
 * `node['appdynamics']['node_name']`
@@ -86,6 +93,7 @@ default_attributes (
     'app_name' => 'my app',
     'tier_name' => 'frontend',
     'node_name' => node.name,
+    'version' => '4.1.2.0',
     'controller' => {
       'host' => 'my-controller',
       'port' => '8181',
@@ -107,7 +115,7 @@ default_attributes (
 
 The `dotnet_agent` recipe has some additional attributes you may set:
 
-* `node['appdynamics']['dotnet_agent']['version']` - The version of the .net agent you wish to use. defaults to `latest`
+* `node['appdynamics']['dotnet_agent']['version']` - The version of the .net agent you wish to use. If not set, `node['appdynamics']['version']` is used.
 * `node['appdynamics']['dotnet_agent']['install_dir']` - Set to the path you want the agent to be installed at, it defaults to `C:\Program Files\Appdynamics`.
 * `node['appdynamics']['dotnet_agent']['source']` - base url for downloading the agent from.
 * `node['appdynamics']['dotnet_agent']['logfiles_dir']` - Set the logfile directory. defaults to `C:\DotNetAgent\Logs`.
@@ -120,6 +128,7 @@ The `dotnet_agent` recipe has some additional attributes you may set:
 
 **Step 1.** Set the following node attributes (documented above):
 
+* `node['appdynamics']['version']`
 * `node['appdynamics']['app_name']`
 * `node['appdynamics']['controller']['host']`
 * `node['appdynamics']['controller']['port']`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
+default['appdynamics']['version'] = nil
+
 default['appdynamics']['app_name'] = nil
 default['appdynamics']['tier_name'] = nil
 default['appdynamics']['node_name'] = nil
@@ -14,4 +16,5 @@ default['appdynamics']['http_proxy']['user'] = nil
 default['appdynamics']['http_proxy']['password_file'] = nil
 
 default['appdynamics']['unzip_command'] = 'unzip -qq'
-default['appdynamics']['agent_zip'] = "#{Chef::Config[:file_cache_path]}/AppDynamicsJavaAgent.zip"
+
+default['appdynamics']['packages_site'] = 'https://packages.appdynamics.com/'

--- a/attributes/dotnet_agent.rb
+++ b/attributes/dotnet_agent.rb
@@ -1,18 +1,10 @@
-default['appdynamics']['dotnet_agent']['version'] = 'latest'
-default['appdynamics']['dotnet_agent']['source'] = 'https://packages.appdynamics.com/dotnet'
-default['appdynamics']['dotnet_agent']['checksum'] = '63837240238fb5b25f40f27f0e58e3bcd2041d87fe79b8529a34eb2282668d82'
+default['appdynamics']['dotnet_agent']['version'] = nil
+default['appdynamics']['dotnet_agent']['source'] = nil
 default['appdynamics']['dotnet_agent']['install_dir'] = 'C:\Program Files\Appdynamics'
 default['appdynamics']['dotnet_agent']['logfiles_dir'] = 'C:\DotNetAgent\Logs'
 default['appdynamics']['dotnet_agent']['template']['cookbook'] = 'appdynamics'
 default['appdynamics']['dotnet_agent']['template']['source'] = 'dotnet/setup.config.erb'
 default['appdynamics']['dotnet_agent']['instrument_iis'] = false
-
-# Check the bitness of the OS to determine the installer to download and run
-if node['kernel']['machine'] != 'x86_64'
-  default['appdynamics']['dotnet_agent']['package_file'] = 'dotNetAgentSetup.msi'
-else
-  default['appdynamics']['dotnet_agent']['package_file'] = 'dotNetAgentSetup64.msi'
-end
 
 # instrumenting windows services and/or standalone apps
 # standalone apps must have restart = false because the service resource will fail trying to restart a non-windows service

--- a/attributes/java_agent.rb
+++ b/attributes/java_agent.rb
@@ -1,5 +1,6 @@
-default['appdynamics']['java_agent']['version'] = 'latest'
-default['appdynamics']['java_agent']['source'] = nil # 'https://packages.appdynamics.com/machine/%{version}/JavaAppAgent.zip'
+default['appdynamics']['java_agent']['version'] = nil
+default['appdynamics']['java_agent']['source'] = nil
+default['appdynamics']['java_agent']['ibm_jvm'] = false
 default['appdynamics']['java_agent']['checksum'] = nil
 default['appdynamics']['java_agent']['install_dir'] = '/opt/appdynamics/javaagent'
 default['appdynamics']['java_agent']['owner'] = 'root'
@@ -10,3 +11,4 @@ default['appdynamics']['java_agent']['template']['source'] = 'java/controller-in
 
 default['appdynamics']['java_agent']['java'] = '/usr/bin/java'
 default['appdynamics']['java_agent']['java_params'] = '-Xmx32m'
+default['appdynamics']['java_agent']['zip'] = "#{Chef::Config[:file_cache_path]}/AppDynamicsJavaAgent.zip"

--- a/attributes/machine_agent.rb
+++ b/attributes/machine_agent.rb
@@ -1,5 +1,6 @@
-default['appdynamics']['machine_agent']['version'] = 'latest'
-default['appdynamics']['machine_agent']['source'] = nil # 'https://packages.appdynamics.com/machine/%{version}/MachineAgent.zip'
+default['appdynamics']['machine_agent']['version'] = nil
+default['appdynamics']['machine_agent']['source'] = nil
+default['appdynamics']['machine_agent']['use_bundled_package'] = false
 default['appdynamics']['machine_agent']['checksum'] = nil
 default['appdynamics']['machine_agent']['install_dir'] = '/opt/appdynamics/machineagent'
 default['appdynamics']['machine_agent']['owner'] = 'root'

--- a/attributes/nodejs_agent.rb
+++ b/attributes/nodejs_agent.rb
@@ -1,6 +1,6 @@
 default['appdynamics']['nodejs_agent']['path'] = nil
 default['appdynamics']['nodejs_agent']['action'] = :install
-default['appdynamics']['nodejs_agent']['version'] = 'latest'
+default['appdynamics']['nodejs_agent']['version'] = nil
 default['appdynamics']['nodejs_agent']['helper_file'] = 'appd.js'
 
 default['appdynamics']['nodejs_agent']['template']['cookbook'] = 'appdynamics'

--- a/attributes/python_agent.rb
+++ b/attributes/python_agent.rb
@@ -1,6 +1,6 @@
 default['appdynamics']['python_agent']['virtualenv'] = nil
 default['appdynamics']['python_agent']['action'] = :install
-default['appdynamics']['python_agent']['version'] = 'latest'
+default['appdynamics']['python_agent']['version'] = nil
 default['appdynamics']['python_agent']['prerelease'] = true
 default['appdynamics']['python_agent']['config_file'] = '/etc/appdynamics-python.cfg'
 default['appdynamics']['python_agent']['user'] = 'root'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,11 @@
-name 'appdynamics'
-maintainer 'Appdynamics'
-description 'Installs/Configures appdynamic agents'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
+name              'appdynamics'
+version           '0.1.2'
+
+maintainer        'AppDynamics'
+description       'Installs and configures AppDynamics agents'
+long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+source_url        'https://github.com/appdynamics/appdynamics-cookbooks'        if respond_to?(:source_url)
+issues_url        'https://github.com/appdynamics/appdynamics-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'windows'
 depends 'python'
@@ -10,3 +13,24 @@ depends 'nodejs'
 depends 'java'
 depends 'apt'
 depends 'powershell'
+
+# Red Hat
+supports 'amazon'
+supports 'centos'
+supports 'fedora'
+supports 'oracle'
+supports 'redhat'
+supports 'scientific'
+
+# Debian
+supports 'debian'
+supports 'linuxmint'
+supports 'ubuntu'
+
+# Mac
+supports 'mac_os_x'
+supports 'mac_os_x_server'
+
+# Windows
+supports 'mswin'
+supports 'windows'

--- a/recipes/nodejs_agent.rb
+++ b/recipes/nodejs_agent.rb
@@ -4,9 +4,12 @@ agent = node['appdynamics']['nodejs_agent']
 controller = node['appdynamics']['controller']
 http_proxy = node['appdynamics']['http_proxy']
 
+agent_version = agent['version'] || node['appdynamics']['version']
+fail 'You must specify either node[\'appdynamics\'][\'version\'] or node[\'appdynamics\'][\'nodejs_agent\'][\'version\']' unless agent_version
+
 nodejs_npm 'appdynamics' do
   path agent['path'] if agent['path']
-  version agent['version'] unless agent['version'] == 'latest'
+  version agent_version
   user agent['install_user'] if agent['install_user']
   group agent['install_group'] if agent['install_group']
 end

--- a/recipes/python_agent.rb
+++ b/recipes/python_agent.rb
@@ -2,10 +2,13 @@ agent = node['appdynamics']['python_agent']
 controller = node['appdynamics']['controller']
 http_proxy = node['appdynamics']['http_proxy']
 
+agent_version = agent['version'] || node['appdynamics']['version']
+fail 'You must specify either node[\'appdynamics\'][\'version\'] or node[\'appdynamics\'][\'python_agent\'][\'version\']' unless agent_version
+
 python_pip 'appdynamics' do
   virtualenv agent['virtualenv'] if agent['virtualenv']
   action agent['action']
-  version agent['version'] if agent['version'] != 'latest'
+  version agent_version
   user agent['user']
   group agent['group']
   options '--pre' if agent['prerelease']

--- a/spec/unit/dotnet_agent_spec.rb
+++ b/spec/unit/dotnet_agent_spec.rb
@@ -53,7 +53,11 @@ describe 'appdynamics::dotnet_agent' do
       expect(chef_run).to install_windows_feature('IIS-RequestMonitor')
     end
     it 'installs package AppDynamics .NET Agent' do
-      expect(chef_run).to install_package('AppDynamics .NET Agent')
+      chef_run.node.set['appdynamics']['dotnet_agent']['version'] = '4.1.2.0'
+      chef_run.converge(described_recipe)
+      expect(chef_run).to install_package('AppDynamics .NET Agent').with(
+        'package' => 'https://packages.appdynamics.com/dotnet/4.1.2.0/dotNetAgentSetup64-4.1.2.0.msi'
+      )
     end
     it 'enables & starts AppDynamics.Agent.Coordinator_service' do
       expect(chef_run).to enable_service('AppDynamics.Agent.Coordinator_service')


### PR DESCRIPTION
@spuder @akemner 

This pull request adds the ability to download agents from packages.appdynamics.com. It also removes the concept of a "latest" version (because packages.appdynamics.com doesn't currently support such a notion), making it necessary to set either the new `node['appdynamics']['version']` attribute or an agent-specific `npde['appdynamics']['FOO_agent']['version']` attribute.