### PR TITLE
Fix test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,18 @@ appdynamics CHANGELOG
 
 This file is used to list changes made in each version of the appdynamics cookbook.
 
+0.1.3
+-----
+- [akemner] - add maintainer_email and fix spec failures
+
+0.1.2
+-----
+- [dkoepke] - Add support for packages.appdynamics.com, remove "latest" version concept.
+
 0.1.1
 -----
-- [Al Kemner] - dotnet_agent - add standalone/windows service instrumentation support, includes chefspec and serverspec test for the changes. 
+- [akemner] - dotnet_agent - add standalone/windows service instrumentation support, includes chefspec and serverspec test for the changes. 
 
 0.1.0
 -----
-- [Al Kemner] - bump metadata version, add changelog.md, resolve FoodCritic/Rubocop failures for all files, add unit(chefspec) & integration(serverspec) testing for dotnet_agent.rb. remove checksum, notify to template resource so AppDynamics Agent Coordinator restart if template gets changed, subscribe IIS Restart script to AppDynamics Agent Coordinator. 
+- [akemner] - bump metadata version, add changelog.md, resolve FoodCritic/Rubocop failures for all files, add unit(chefspec) & integration(serverspec) testing for dotnet_agent.rb. remove checksum, notify to template resource so AppDynamics Agent Coordinator restart if template gets changed, subscribe IIS Restart script to AppDynamics Agent Coordinator. 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,4 +17,4 @@ default['appdynamics']['http_proxy']['password_file'] = nil
 
 default['appdynamics']['unzip_command'] = 'unzip -qq'
 
-default['appdynamics']['packages_site'] = 'https://packages.appdynamics.com/'
+default['appdynamics']['packages_site'] = 'https://packages.appdynamics.com'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,8 @@
 name              'appdynamics'
-version           '0.1.2'
+version           '0.1.3'
 
 maintainer        'AppDynamics'
+maintainer_email  'help@appdynamics.com'
 description       'Installs and configures AppDynamics agents'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url        'https://github.com/appdynamics/appdynamics-cookbooks'        if respond_to?(:source_url)

--- a/spec/unit/dotnet_agent_spec.rb
+++ b/spec/unit/dotnet_agent_spec.rb
@@ -5,6 +5,7 @@ describe 'appdynamics::dotnet_agent' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2') do |node|
         node.automatic['kernel']['machine'] = 'x86_64'
+        node.set['appdynamics']['dotnet_agent']['version'] = '4.1.3.0'
         node.set['appdynamics']['dotnet_agent']['template']['cookbook'] = 'appdynamics'
         node.set['appdynamics']['dotnet_agent']['template']['source'] = 'dotnet/setup.config.erb'
         node.set['appdynamics']['dotnet_agent']['standalone_apps'] = [
@@ -53,11 +54,7 @@ describe 'appdynamics::dotnet_agent' do
       expect(chef_run).to install_windows_feature('IIS-RequestMonitor')
     end
     it 'installs package AppDynamics .NET Agent' do
-      chef_run.node.set['appdynamics']['dotnet_agent']['version'] = '4.1.2.0'
-      chef_run.converge(described_recipe)
-      expect(chef_run).to install_package('AppDynamics .NET Agent').with(
-        'package' => 'https://packages.appdynamics.com/dotnet/4.1.2.0/dotNetAgentSetup64-4.1.2.0.msi'
-      )
+      expect(chef_run).to install_package('AppDynamics .NET Agent')
     end
     it 'enables & starts AppDynamics.Agent.Coordinator_service' do
       expect(chef_run).to enable_service('AppDynamics.Agent.Coordinator_service')
@@ -101,6 +98,7 @@ describe 'appdynamics::dotnet_agent' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'windows', version: '2012R2') do |node|
         node.automatic['kernel']['machine'] = 'x86_64'
+        node.set['appdynamics']['dotnet_agent']['version'] = '4.1.3.0'
         node.set['appdynamics']['dotnet_agent']['template']['cookbook'] = 'appdynamics'
         node.set['appdynamics']['dotnet_agent']['template']['source'] = 'dotnet/setup.config.erb'
         node.set['appdynamics']['dotnet_agent']['standalone_apps'] = [

--- a/spec/unit/dotnet_agent_spec.rb
+++ b/spec/unit/dotnet_agent_spec.rb
@@ -54,7 +54,9 @@ describe 'appdynamics::dotnet_agent' do
       expect(chef_run).to install_windows_feature('IIS-RequestMonitor')
     end
     it 'installs package AppDynamics .NET Agent' do
-      expect(chef_run).to install_package('AppDynamics .NET Agent')
+      expect(chef_run).to install_package('AppDynamics .NET Agent').with(
+        'source' => 'https://packages.appdynamics.com/dotnet/4.1.3.0/dotNetAgentSetup64-4.1.3.0.msi'
+      )
     end
     it 'enables & starts AppDynamics.Agent.Coordinator_service' do
       expect(chef_run).to enable_service('AppDynamics.Agent.Coordinator_service')

--- a/spec/unit/nodejs_agent_spec.rb
+++ b/spec/unit/nodejs_agent_spec.rb
@@ -8,7 +8,7 @@ describe 'appdynamics::nodejs_agent' do
       node.set['appdynamics']['node_name'] = 'node-name'
       node.set['appdynamics']['controller']['host'] = 'controller-host'
       node.set['appdynamics']['controller']['port'] = 1234
-
+      node.set['appdynamics']['nodejs_agent']['version'] = '4.1.3.0'
       node.set['appdynamics']['nodejs_agent']['path'] = '/some/path/here'
     end.converge(described_recipe)
   end

--- a/spec/unit/python_agent_spec.rb
+++ b/spec/unit/python_agent_spec.rb
@@ -7,7 +7,7 @@ describe 'appdynamics::python_agent' do
       appd['app_name'] = 'app-name'
       appd['tier_name'] = 'tier-name'
       appd['node_name'] = 'node-name'
-
+      appd['version'] = '4.1.3.0'
       appd['controller']['host'] = 'controller-host'
       appd['controller']['port'] = 1234
     end.converge(described_recipe)


### PR DESCRIPTION
spec tests were failing because of the requirements to set version. add maintainer_email = help@appdynamics.com, this was causing knife upload to fail to upload the cookbook. 