### PR TITLE
dotnet_agent - add support for dynamic integration test on windows

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -32,31 +32,35 @@ provisioner:
           password_file: /tmp/foo/bar
 
 transport:
-  ssh_key: ~/.ssh/<%= ENV['AWS_SSH_KEY'] %>.pem
+  ssh_key: <%= ENV['SSH_KEY_PATH'] %><%= ENV['AWS_SSH_KEY'] %>.pem
 
 platforms:
   - name: centos
     driver:
       image_id: <%= ENV['AWS_CENTOS_AMI_ID'] %>
       instance_type: <%= ENV['LINUX_INSTANCE_SIZE'] %>
+      user_data: <%= ENV['LINUX_USER_DATA_PATH'] %>
     transport:
       username: <%= ENV['AWS_CENTOS_USERNAME'] %>
   - name: ubuntu
     driver:
       image_id: <%= ENV['AWS_UBUNTU_AMI_ID'] %>
       instance_type: <%= ENV['LINUX_INSTANCE_SIZE'] %>
+      user_data: <%= ENV['LINUX_USER_DATA_PATH'] %>
     transport:
       username: <%= ENV['AWS_UBUNTU_USERNAME'] %>
   - name: windows-2012r2
     driver:
       image_id: <%= ENV['AWS_WINDOWS2012R2_AMI_ID'] %>
       instance_type: <%= ENV['WINDOWS_INSTANCE_SIZE'] %>
+      user_data: <%= ENV['WINDOWS_USER_DATA_PATH'] %>
     transport:
       name: winrm
   - name: windows-2008r2
     driver:
       image_id: <%= ENV['AWS_WINDOWS2008R2_AMI_ID'] %>
       instance_type: <%= ENV['WINDOWS_INSTANCE_SIZE'] %>
+      user_data: <%= ENV['WINDOWS_USER_DATA_PATH'] %>
     transport:
       name: winrm
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -96,6 +96,7 @@ suites:
 
   - name: dotnet_agent
     run_list:
+      - recipe[test-helper::default]
       - recipe[iis]
       - recipe[appdynamics::dotnet_agent]
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ appdynamics CHANGELOG
 
 This file is used to list changes made in each version of the appdynamics cookbook.
 
+0.2.3
+-----
+- [akemner] - dynamic integration testing for windows with fixture cookbook test-helper
+
 0.2.2
 -----
 - [dkoepke] - use windows_package instead of package--we were seeing `package` fail in certain invocations of chef-client due the `source` attribute magically growing a drive letter; update Travis to use rake test

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name              'appdynamics'
-version           '0.2.2'
+version           '0.2.3'
 
 maintainer        'AppDynamics'
 maintainer_email  'help@appdynamics.com'

--- a/test/fixtures/cookbooks/test-helper/README.md
+++ b/test/fixtures/cookbooks/test-helper/README.md
@@ -1,1 +1,57 @@
 Provides usable node information as a tmp json file.
+
+##Configuration example
+
+Include in `.kitchen.yml`:
+```
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: centos-6.6
+
+suites:
+  - name: default
+    run_list:
+      - recipe[test-helper]
+      - recipe[<<<<>>>>>]
+```
+
+
+##Usage with Server Spec
+Linux: Update / Configure `spec_helper.rb` to contain:
+```
+require 'serverspec'
+require 'pathname'
+require 'json'
+
+set :backend, :exec
+
+set :path, '/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:$PATH'
+$node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+```
+Windows: Update / Configure `spec_helper.rb` to contain:
+```
+require 'serverspec'
+require 'pathname'
+require 'json'
+
+set :backend, :cmd
+set :os, :family => 'windows'
+
+$node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
+```
+
+#####Usage in tests:
+```
+describe file("#{$node['appdynamics']['java_agent']['install_dir']}/javaagent/conf") do
+  it 'is a directory' do
+    expect(subject).to be_directory
+  end
+  it { should be_owned_by "#{$node['appdynamics']['java_agent']['owner']}" }
+end
+```

--- a/test/fixtures/cookbooks/test-helper/README.md
+++ b/test/fixtures/cookbooks/test-helper/README.md
@@ -20,32 +20,25 @@ suites:
       - recipe[test-helper]
       - recipe[<<<<>>>>>]
 ```
-
-
 ##Usage with Server Spec
-Linux: Update / Configure `spec_helper.rb` to contain:
+Update / Configure `spec_helper.rb` to contain:
 ```
 require 'serverspec'
 require 'pathname'
 require 'json'
 
-set :backend, :exec
+if ENV['OS'] == 'Windows_NT'
+  set :backend, :cmd
+  # On Windows, set the target host's OS explicitely
+  set :os, :family => 'windows'
+  $node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
+else
+  set :backend, :exec
+  $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+end
 
-set :path, '/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:$PATH'
-$node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+set :path, '/sbin:/usr/local/sbin:$PATH' unless os[:family] == 'windows'
 ```
-Windows: Update / Configure `spec_helper.rb` to contain:
-```
-require 'serverspec'
-require 'pathname'
-require 'json'
-
-set :backend, :cmd
-set :os, :family => 'windows'
-
-$node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
-```
-
 #####Usage in tests:
 ```
 describe file("#{$node['appdynamics']['java_agent']['install_dir']}/javaagent/conf") do

--- a/test/fixtures/cookbooks/test-helper/attributes/default.rb
+++ b/test/fixtures/cookbooks/test-helper/attributes/default.rb
@@ -1,0 +1,8 @@
+case node['platform_family']
+when 'debian', 'rhel', 'fedora'
+  default['test-helper']['node_attributes_path'] = '/tmp/serverspec/'
+when 'windows'
+  default['test-helper']['node_attributes_path'] = "#{node['kernel']['os_info']['system_drive']}\\windows\\temp\\serverspec\\"
+else
+  Chef::Log.error("test-helper is not supported on #{node['platform_family']}")
+end

--- a/test/fixtures/cookbooks/test-helper/recipes/default.rb
+++ b/test/fixtures/cookbooks/test-helper/recipes/default.rb
@@ -3,25 +3,13 @@ chef_gem 'activesupport'
 require 'pathname'
 require 'active_support/core_ext/hash/deep_merge'
 
-case node['platform_family']
-when 'debian', 'rhel', 'fedora'
-  temp_path = '/tmp/serverspec/'
-  directory temp_path do
-    recursive true
-  end
+directory node['test-helper']['node_attributes_path'] do
+  recursive true
+end
 
-  file "#{temp_path}node.json" do
-    owner 'root'
-    mode '0400'
-  end
-when 'windows'
-  temp_path = 'c:\\windows\\temp\\serverspec\\'
-  directory temp_path do
-    recursive true
-  end
-
-  file "#{temp_path}node.json" do
-  end
+file "#{node['test-helper']['node_attributes_path']}node.json" do
+  owner 'root' unless node['platform_family'] == 'windows'
+  mode '0400' unless node['platform_family'] == 'windows'
 end
 
 log "Dumping attributes to 'node.json'"
@@ -42,6 +30,6 @@ ruby_block 'dump_node_attributes' do
     recipe_json << " \] }"
     attrs = attrs.deep_merge(JSON.parse(recipe_json))
 
-    File.open("#{temp_path}node.json", 'w') { |file| file.write(JSON.pretty_generate(attrs)) }
+    File.open("#{node['test-helper']['node_attributes_path']}node.json", 'w') { |file| file.write(JSON.pretty_generate(attrs)) }
   end
 end

--- a/test/fixtures/cookbooks/test-helper/recipes/default.rb
+++ b/test/fixtures/cookbooks/test-helper/recipes/default.rb
@@ -3,16 +3,28 @@ chef_gem 'activesupport'
 require 'pathname'
 require 'active_support/core_ext/hash/deep_merge'
 
-directory '/tmp/serverspec' do
-  recursive true
+case node['platform_family']
+when 'debian', 'rhel', 'fedora'
+  temp_path = '/tmp/serverspec/'
+  directory temp_path do
+    recursive true
+  end
+
+  file "#{temp_path}node.json" do
+    owner 'root'
+    mode '0400'
+  end
+when 'windows'
+  temp_path = 'c:\\windows\\temp\\serverspec\\'
+  directory temp_path do
+    recursive true
+  end
+
+  file "#{temp_path}node.json" do
+  end
 end
 
-file '/tmp/serverspec/node.json' do
-  owner 'root'
-  mode '400'
-end
-
-log "Dumping attributes to '/tmp/serverspec/node.json."
+log "Dumping attributes to 'node.json'"
 
 ruby_block 'dump_node_attributes' do
   block do
@@ -20,6 +32,7 @@ ruby_block 'dump_node_attributes' do
 
     attrs = {}
 
+    attrs = attrs.deep_merge(node.automatic_attrs) unless node.automatic_attrs.empty?
     attrs = attrs.deep_merge(node.default_attrs) unless node.default_attrs.empty?
     attrs = attrs.deep_merge(node.normal_attrs) unless node.normal_attrs.empty?
     attrs = attrs.deep_merge(node.override_attrs) unless node.override_attrs.empty?
@@ -29,6 +42,6 @@ ruby_block 'dump_node_attributes' do
     recipe_json << " \] }"
     attrs = attrs.deep_merge(JSON.parse(recipe_json))
 
-    File.open('/tmp/serverspec/node.json', 'w') { |file| file.write(JSON.pretty_generate(attrs)) }
+    File.open("#{temp_path}node.json", 'w') { |file| file.write(JSON.pretty_generate(attrs)) }
   end
 end

--- a/test/integration/dotnet_agent/serverspec/dotnet_agent_spec.rb
+++ b/test/integration/dotnet_agent/serverspec/dotnet_agent_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe file('c:\\windows\\Temp') do
+describe file("#{$node['kernel']['os_info']['windows_directory']}\\Temp") do
   it 'is a directory' do
     expect(subject).to be_directory
   end
@@ -26,7 +26,7 @@ describe windows_feature('IIS-RequestMonitor') do
     expect(subject).to be_installed
   end
 end
-describe file('C:\\ProgramData\\AppDynamics\\DotNetAgent\\Config\\config.xml') do
+describe file("#{$node['kernel']['os_info']['system_drive']}\\ProgramData\\AppDynamics\\DotNetAgent\\Config\\config.xml") do
   it 'is a file' do
     expect(subject).to be_file
   end

--- a/test/integration/dotnet_agent/serverspec/spec_helper.rb
+++ b/test/integration/dotnet_agent/serverspec/spec_helper.rb
@@ -2,7 +2,14 @@ require 'serverspec'
 require 'pathname'
 require 'json'
 
-set :backend, :cmd
-set :os, :family => 'windows'
+if ENV['OS'] == 'Windows_NT'
+  set :backend, :cmd
+  # On Windows, set the target host's OS explicitely
+  set :os, :family => 'windows'
+  $node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
+else
+  set :backend, :exec
+  $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+end
 
-$node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
+set :path, '/sbin:/usr/local/sbin:$PATH' unless os[:family] == 'windows'

--- a/test/integration/dotnet_agent/serverspec/spec_helper.rb
+++ b/test/integration/dotnet_agent/serverspec/spec_helper.rb
@@ -1,4 +1,8 @@
 require 'serverspec'
+require 'pathname'
+require 'json'
 
 set :backend, :cmd
 set :os, :family => 'windows'
+
+$node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))

--- a/test/integration/java_agent/serverspec/spec_helper.rb
+++ b/test/integration/java_agent/serverspec/spec_helper.rb
@@ -2,7 +2,14 @@ require 'serverspec'
 require 'pathname'
 require 'json'
 
-set :backend, :exec
+if ENV['OS'] == 'Windows_NT'
+  set :backend, :cmd
+  # On Windows, set the target host's OS explicitely
+  set :os, :family => 'windows'
+  $node = ::JSON.parse(File.read('c:\windows\temp\serverspec\node.json'))
+else
+  set :backend, :exec
+  $node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+end
 
-set :path, '/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:$PATH'
-$node = ::JSON.parse(File.read('/tmp/serverspec/node.json'))
+set :path, '/sbin:/usr/local/sbin:$PATH' unless os[:family] == 'windows'


### PR DESCRIPTION
this PR adds windows support to the fixture test-helper cookbook and modifies the integration tests to take advantage of that. I also modified the kitchen.ec2 file to include user-data variables and the ssh_key path to support testing on either windows or linux systems

@dkoepke @thiru-chidambaram 