### PR TITLE
Hotfix to dotnet config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ appdynamics CHANGELOG
 
 This file is used to list changes made in each version of the appdynamics cookbook.
 
+0.2.4
+-----
+- [nmcginnis] - Removed erroneous characters in dotnet template  which causes issues with auto instrumentation.
+
 0.2.3
 -----
 - [akemner] - dynamic integration testing for windows with fixture cookbook test-helper

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name              'appdynamics'
-version           '0.2.3'
+version           '0.2.4'
 
 maintainer        'AppDynamics'
 maintainer_email  'help@appdynamics.com'

--- a/templates/default/dotnet/config.erb
+++ b/templates/default/dotnet/config.erb
@@ -8,7 +8,7 @@
   <machine-agent />
   <app-agents>
     <IIS>
-      <% if @instrument_iis -%><automatic />%><% end -%>
+      <% if @instrument_iis -%><automatic /><% end -%>
     </IIS>
     <% unless @standalone_apps.nil? %> 
     <standalone-applications> 


### PR DESCRIPTION
Removed erroneous characters in dotnet config template which causes issues with auto instrumentation.