### PR TITLE
locks activesupport gem to version 4.x.x

### DIFF
--- a/test/fixtures/cookbooks/test-helper/recipes/default.rb
+++ b/test/fixtures/cookbooks/test-helper/recipes/default.rb
@@ -1,4 +1,6 @@
-chef_gem 'activesupport'
+chef_gem 'activesupport' do
+  version '4.2.7.1' # http://bit.ly/2czDmhs
+end
 
 require 'pathname'
 require 'active_support/core_ext/hash/deep_merge'


### PR DESCRIPTION
Resolves issue #52 