### PR TITLE
Locks dependent cookbooks

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,13 +8,13 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url        'https://github.com/appdynamics/appdynamics-cookbooks'        if respond_to?(:source_url)
 issues_url        'https://github.com/appdynamics/appdynamics-cookbooks/issues' if respond_to?(:issues_url)
 
-depends 'windows'
-depends 'python'
-depends 'nodejs'
-depends 'java'
-depends 'apt'
-depends 'powershell'
-depends 'ark'
+depends 'windows', '~> 1.44.3'
+depends 'python', '~> 1.4.6'
+depends 'nodejs', '~> 2.4.4'
+depends 'java', '~> 1.42.0'
+depends 'apt', '~> 4.0.2'
+depends 'powershell', '~> 5.0.0'
+depends 'ark', '~> 1.1.0'
 
 # Red Hat
 supports 'amazon'


### PR DESCRIPTION
Fixes issue #50 
Ark cookbook 1.2.0 requires that 7zip is installed on the machine. 
Reverts ark dependency back to 1.1.0. 
