### PR TITLE
init script bugfix & flexibility

### DIFF
--- a/attributes/machine_agent.rb
+++ b/attributes/machine_agent.rb
@@ -7,9 +7,16 @@ default['appdynamics']['machine_agent']['owner'] = 'root'
 default['appdynamics']['machine_agent']['group'] = 'root'
 
 default['appdynamics']['machine_agent']['init_script'] = '/etc/init.d/appdynamics_machine_agent'
+default['appdynamics']['machine_agent']['pid_file'] = '/var/run/appdynamics_machine_agent.pid'
 
 default['appdynamics']['machine_agent']['template']['cookbook'] = 'appdynamics'
 default['appdynamics']['machine_agent']['template']['source'] = 'machine/controller-info.xml.erb'
+
+default['appdynamics']['machine_agent']['init']['cookbook'] = 'appdynamics'
+default['appdynamics']['machine_agent']['init']['source'] = 'machine/init.d.erb'
+
+default['appdynamics']['machine_agent']['run_sh']['cookbook'] = 'appdynamics'
+default['appdynamics']['machine_agent']['run_sh']['source'] = 'machine/run.sh.erb'
 
 default['appdynamics']['machine_agent']['java'] = '/usr/bin/java'
 default['appdynamics']['machine_agent']['java_params'] = '-Xmx32m'

--- a/recipes/machine_agent.rb
+++ b/recipes/machine_agent.rb
@@ -51,14 +51,16 @@ remote_file agent_zip do
 end
 
 template "#{agent['install_dir']}/run.sh" do
-  source 'machine/run.sh.erb'
+  cookbook agent['run_sh']['cookbook']
+  source agent['run_sh']['source']
   owner agent['owner']
   group agent['group']
   mode '0744'
   variables(
     :java => agent['java'],
     :java_params => agent['java_params'],
-    :install_dir => agent['install_dir']
+    :install_dir => agent['install_dir'],
+    :pid_file => agent['pid_file']
   )
 end
 
@@ -68,9 +70,11 @@ execute 'unzip-appdynamics-machine-agent' do
 end
 
 template agent['init_script'] do
-  source 'machine/init.d.erb'
+  cookbook agent['init']['cookbook']
+  source agent['init']['source']
   variables(
-    :install_dir => agent['install_dir']
+    :install_dir => agent['install_dir'],
+    :pid_file => agent['pid_file']
   )
   owner agent['owner']
   group agent['group']

--- a/templates/default/machine/init.d.erb
+++ b/templates/default/machine/init.d.erb
@@ -18,18 +18,20 @@ fi
 INSTALL_DIR="<%= @install_dir %>"
 RETVAL=0
 PROG="$INSTALL_DIR/run.sh"
+pid_file="<%= @pid_file %>"
 
 start() {
     echo -n $"Starting AppDynamics machine agent:"
-    "$PROG"
+    daemon --pidfile=${pid_file} ${PROG}
     RETVAL=$?
     echo
 }
 
 stop() {
     echo -n $"Stopping AppDynamics machine agent:"
-    killproc "$PROG" -TERM
+    killproc -p ${pid_file} "$PROG" -TERM
     RETVAL=$?
+    [ $? -eq 0 ] && rm -f ${pid_file}
     echo
 }
 

--- a/templates/default/machine/run.sh.erb
+++ b/templates/default/machine/run.sh.erb
@@ -1,2 +1,3 @@
 #!/bin/sh
 "<%= @java %>" <%= @java_params %> -jar "<%= @install_dir %>/machineagent.jar" &
+echo $! > <%= @pid_file %>


### PR DESCRIPTION
- 'killproc' does not see run.sh because run.sh exits when java is put into the background
- Add attribute for appdynamics_machine_agent pid file
- Add attribute for init.d.erb template cookbook & source
- Add attribute for run.sh.erb template cookbook & source
- run.sh saves pid of background java process to pid_file attribute target
- init.d uses 'daemon' function with --pidfile and 'killproc' with -p