### PR TITLE
Chef 13 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,6 +27,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+  - name: ubuntu-16.04
   - name: centos-6.7
   - name: windows2012r2
     driver_config:
@@ -59,10 +60,10 @@ suites:
   - name: python_agent
     run_list:
       - recipe[apt::default]
-      - recipe[python::default]
       - recipe[appdynamics::python_agent]
     attributes:
       appdynamics:
+        version: '4.3.9.0'
         python_agent:
           debug: true
           dir: '/opt/pyagent'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ source_url        'https://github.com/appdynamics/appdynamics-cookbooks'        
 issues_url        'https://github.com/appdynamics/appdynamics-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'windows', '~> 1.44.3'
-depends 'python', '~> 1.4.6'
+depends 'poise-python', '~> 1.6.0'
 depends 'nodejs', '~> 2.4.4'
 depends 'java', '~> 1.42.0'
 depends 'apt', '~> 3.0.0'

--- a/recipes/python_agent.rb
+++ b/recipes/python_agent.rb
@@ -5,13 +5,17 @@ http_proxy = node['appdynamics']['http_proxy']
 agent_version = agent['version'] || node['appdynamics']['version']
 fail 'You must specify either node[\'appdynamics\'][\'version\'] or node[\'appdynamics\'][\'python_agent\'][\'version\']' unless agent_version
 
-python_pip 'appdynamics' do
+python_runtime 'appdynamics' do
+  version '3'
+end
+
+python_package 'appdynamics' do
   virtualenv agent['virtualenv'] if agent['virtualenv']
+  python 'appdynamics' if not agent['virtualenv']
   action agent['action']
   version agent_version
   user agent['user']
-  group agent['group']
-  options '--pre' if agent['prerelease']
+  install_options '--pre' if agent['prerelease']
 end
 
 template agent['config_file'] do


### PR DESCRIPTION
The appdynamics cookbook was not compatible with the latest version of Chef due to a dependency on the deprecated "python" cookbook. This PR switches to the recommended "poise-python" cookbook in order to achieve Chef 13 compatibility.