### PR TITLE
Update default version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,7 @@ provisioner:
   name: chef_zero
   attributes:
     appdynamics:
-      version: '4.1.3.1'
+      version: '4.3.7.1'
       app_name: test-app
       tier_name: test-tier
       node_name: test-node


### PR DESCRIPTION
Resolves issue #81 

Sometime between 4.1.x.x and 4.3.x.x the filename for the machine agent was changed. The cookbook only supports the new name for the machine agent. Bump the default version. 