### PR TITLE
Add support to get status of machine_agent.

### DIFF
--- a/templates/default/machine/init.d.erb
+++ b/templates/default/machine/init.d.erb
@@ -35,6 +35,13 @@ stop() {
     echo
 }
 
+is_running() {
+    [ -f "$pid_file" ] && ps -p `get_pid` > /dev/null 2>&1
+}
+get_pid() {
+    cat "$pid_file"
+}
+
 case "$1" in
     start)
         start
@@ -46,8 +53,15 @@ case "$1" in
         stop
         start
         ;;
+    status)
+       if is_running(); then 
+         echo "Running"
+       else
+         echo "Not running"
+         exit 1
+       fi
     *)
-        echo $"Usage: $0 {start|stop|restart}"
+        echo $"Usage: $0 {start|stop|restart|status}"
         RETVAL=1
         ;;
 esac


### PR DESCRIPTION
This is required in chef 11 versions as it checks status before starting service. So status is required in chef services.
Refere this https://serverfault.com/questions/495969/service-doesnt-start-when-using-chef